### PR TITLE
Added BankGround API to the Training section

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ Name | Author | Description |
 | Pentester Academy | [API security, REST Labs](https://attackdefense.pentesteracademy.com/listing?labtype=rest&subtype=rest-api-security) | Pentester Academy - attack & defense |
 | Corey Ball | [API Security University](https://university.apisec.ai) | APIsec University provides training courses for application security professionals |
 | Grant Ongers | [API top 10 walkthrough](https://securedelivery.io/articles/api-top-ten-walkthrough/) | OWASP API Top 10 CTF Walk-through. |
+| Karel Husa | [BankGround API](https://apimate.eu/bankground.html) | Banking-like REST and GraphQL API for training/learning purposes.                                                                                                             |
 | Hacker101 | [GraphQL challenges](https://www.hackerone.com/ethical-hacker/graphql-week-hacker101-capture-flag-challenges) | GraphQL Week on The Hacker101 Capture the Flag Challenges |
 | OWASP-SKF | [GraphQL Labs](https://demo.securityknowledgeframework.org/labs/view) | GraphQL Labs on the OWASP Security Knowledge Framework |
 | Corey Ball | [Hacking APIs](https://sway.office.com/HVrL2AXUlWGNDHqy) | Hacking APIs: workshop |


### PR DESCRIPTION
Added BankGround API to the Training, workshops and labs section. BankGround API is easily understandable API to learn API principles and its usage. Provides both REST and GraphQL API.