### PR TITLE
Add Pompelmi to REST API tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Name | Author | Description |
 | [TnT-Fuzzer](https://github.com/Teebytes/TnT-Fuzzer) | OpenAPI 2.0 (Swagger) fuzzer written in python. Basically TnT for your API. |
 | [wadl-dumper](https://github.com/dwisiswant0/wadl-dumper) | Dump all available paths and/or endpoints on WADL file. |
 | [WuppieFuzz](https://github.com/TNO-S3/WuppieFuzz) | WuppieFuzz is a coverage-guided REST API fuzzer developed on top of LibAFL, targeting a wide audience of end-users, with a strong focus on ease-of-use, explainability of the discovered flaws and modularity. WuppieFuzz supports all three settings of testing (black box, grey box and white box). |
-|【pompelmi](https://github.com/pompelmi/pompelmi/) | Open-source Node.js tool to harden file upload API endpoints by scanning untrusted files for malware, MIME spoofing, and risky archives before storage. |
+| [Pompelmi](https://github.com/pompelmi/pompelmi/) | Open-source Node.js tool to harden file upload API endpoints by scanning untrusted files for malware, MIME spoofing, and risky archives before storage. |
 |  |  |
 | **SOAP** |
 | [Wsdler](https://github.com/NetSPI/Wsdler)| WSDL Parser extension for Burp. |

--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Name | Author | Description |
 | [TnT-Fuzzer](https://github.com/Teebytes/TnT-Fuzzer) | OpenAPI 2.0 (Swagger) fuzzer written in python. Basically TnT for your API. |
 | [wadl-dumper](https://github.com/dwisiswant0/wadl-dumper) | Dump all available paths and/or endpoints on WADL file. |
 | [WuppieFuzz](https://github.com/TNO-S3/WuppieFuzz) | WuppieFuzz is a coverage-guided REST API fuzzer developed on top of LibAFL, targeting a wide audience of end-users, with a strong focus on ease-of-use, explainability of the discovered flaws and modularity. WuppieFuzz supports all three settings of testing (black box, grey box and white box). |
+|【pompelmi](https://github.com/pompelmi/pompelmi/) | Open-source Node.js tool to harden file upload API endpoints by scanning untrusted files for malware, MIME spoofing, and risky archives before storage. |
 |  |  |
 | **SOAP** |
 | [Wsdler](https://github.com/NetSPI/Wsdler)| WSDL Parser extension for Burp. |


### PR DESCRIPTION
This PR adds [Pompelmi](https://github.com/pompelmi/pompelmi) to the `Tools -> REST APIs` section.

Pompelmi is an open-source Node.js tool that helps harden file upload API endpoints by scanning untrusted files for malware, MIME spoofing, and risky archives before storage.

Repository:
https://github.com/pompelmi/pompelmi